### PR TITLE
Adjust handleTagUpdated to invalidate all queries

### DIFF
--- a/apps/client/src/hooks/useSocketIntegration.ts
+++ b/apps/client/src/hooks/useSocketIntegration.ts
@@ -27,14 +27,7 @@ export const useSocketIntegration = () => {
     const handleTagUpdated = (tag: Tag) => {
       console.log("🏷️ Tag updated via socket:", tag);
 
-      dispatch(
-        api.util.invalidateTags([
-          { type: "Tag", id: "LIST" },
-          { type: "Tag", id: tag.id },
-          { type: "Call", id: "LIST" },
-          { type: "CallTag", id: "LIST" },
-        ]),
-      );
+      dispatch(api.util.invalidateTags(["Tag", "CallTag", "Call"]));
     };
 
     // TASK EVENTS


### PR DESCRIPTION
## Adjust handleTagUpdated to invalidate all queries

- Adjust `handleTagUpdated` to invalidate all queries in order to reflect changes in Call-Tag